### PR TITLE
add \footnote

### DIFF
--- a/slydifi-footnote-scheme.satyh
+++ b/slydifi-footnote-scheme.satyh
@@ -1,0 +1,86 @@
+@require: color
+@require: gr
+
+module FootnoteScheme : sig
+  val start-page: unit -> unit
+  val main: context -> string option -> (int -> inline-boxes) -> (int -> block-boxes) -> inline-boxes
+  val get-footnote-num: string -> string option
+end = struct
+
+  let-mutable footnote-ref <- 0
+  let-mutable first-footnote <- true
+
+  let bar-ratio = 0.5
+
+
+  let start-page () =
+    first-footnote <- true
+
+
+  let generate-footnote-label n =
+    `footnote:` ^ (arabic n)
+
+
+  let promote-another-trial () =
+    register-cross-reference `changed` `T`
+
+  let generate-footnote-ref-label s =
+    `footnote-ref:` ^ s
+
+  let main ctx ref-label ibf bbf =
+    let () = footnote-ref <- !footnote-ref + 1 in
+    let num = !footnote-ref in
+    let () = match ref-label with
+      | Some(l) -> register-cross-reference (generate-footnote-ref-label l) (arabic num)
+      | _ -> ()
+    in
+    let label = generate-footnote-label num in
+    let it-num = embed-string (arabic num) in
+    let size = get-font-size ctx in
+    let ib-num = ibf num in
+    let bb = bbf num in
+    let bb-before =
+      match get-cross-reference label with
+      | Some(`T`) ->
+          let () = display-message (`'` ^ label ^ `': T`) in  % for debug
+          let bar-top-margin = size in
+          let bar-bottom-margin = size *' 0.125 in
+          let wid = get-text-width ctx *' bar-ratio in
+          let ib =
+            inline-graphics wid bar-top-margin bar-bottom-margin (fun (x, y) ->
+              [ stroke 0.5pt Color.black (Gr.line (x, y) (x +' wid, y)); ]
+            ) ++ inline-fil
+          in
+          line-break false false (ctx |> set-paragraph-margin 0pt 0pt) ib
+
+      | _ ->
+          let () = display-message (`'` ^ label ^ `': F`) in  % for debug
+          block-skip (size *' 0.5)
+    in
+      no-break
+        (add-footnote (bb-before +++ bb) ++ ib-num
+          ++ hook-page-break (fun _ _ -> (
+            let () =
+              if !first-footnote then
+                match get-cross-reference label with
+                | Some(`T`) ->
+                    ()
+
+                | _ ->
+                    let () = promote-another-trial () in
+                      register-cross-reference label `T`
+              else
+                match get-cross-reference label with
+                | Some(`F`) ->
+                    ()
+
+                | _ ->
+                    let () = promote-another-trial () in
+                      register-cross-reference label `F`
+            in
+            first-footnote <- false)))
+
+  let get-footnote-num ref-label =
+    get-cross-reference (generate-footnote-ref-label ref-label)
+end
+

--- a/slydifi.satyh
+++ b/slydifi.satyh
@@ -4,8 +4,8 @@
 @require: math
 @require: list
 @require: annot
-@require: footnote-scheme
 @import: slydifi-color
+@import: slydifi-footnote-scheme
 
 
 type imginfo =
@@ -72,6 +72,8 @@ module Slydifi : sig
   direct +fig-abs-pos : [(length * length); imginfo] block-cmd
   direct \fig-right : [imginfo] inline-cmd
   direct \footnote : [inline-text] inline-cmd
+  direct \footnote-just : [string; inline-text] inline-cmd
+  direct \ref-footnote : [string] inline-cmd
   % }}}
 
 end = struct
@@ -692,6 +694,38 @@ end = struct
       % }}}
 
     % \footnote{} command {{{
+
+
+  let-inline ctx \footnote-just ref-label it =
+    let bbf num =
+      let it-num = embed-string (arabic num) in
+      let ctx =
+        ctx |> set-font-size (font-size-footnote *' 0.9)
+            |> set-leading (font-size-footnote *' 1.2)
+            |> set-paragraph-margin (font-size-footnote *' 0.5) (font-size-footnote *' 0.5)
+          %temporary
+      in
+        line-break false false ctx (read-inline ctx {#it-num; #it;} ++ inline-fil)
+    in
+      FootnoteScheme.main ctx (Some(ref-label)) (fun _ -> inline-nil) bbf
+
+  let-inline ctx \ref-footnote ref-label =
+    let size = get-font-size ctx in
+    let ctx =
+      ctx |> set-font-size (size *' 0.75)
+          |> set-manual-rising (size *' 0.25)
+    in
+    let ctx =
+      ctx |> set-font-size (size *' 0.75)
+          |> set-manual-rising (size *' 0.25)
+    in
+    match FootnoteScheme.get-footnote-num ref-label with
+    | Some(n) ->
+      let it-num = embed-string n in
+      read-inline ctx {\*#it-num;}
+    | _ ->
+      read-inline ctx {\*?}
+
   let-inline ctx \footnote it =
     let size = get-font-size ctx in
     let ibf num =
@@ -712,7 +746,7 @@ end = struct
       in
         line-break false false ctx (read-inline ctx {#it-num; #it;} ++ inline-fil)
     in
-      FootnoteScheme.main ctx ibf bbf
+      FootnoteScheme.main ctx None ibf bbf
 
 
     %}}}

--- a/slydifi.satyh
+++ b/slydifi.satyh
@@ -4,6 +4,7 @@
 @require: math
 @require: list
 @require: annot
+@require: footnote-scheme
 @import: slydifi-color
 
 
@@ -70,6 +71,7 @@ module Slydifi : sig
   direct \fig-abs-pos : [(length * length); imginfo] inline-cmd
   direct +fig-abs-pos : [(length * length); imginfo] block-cmd
   direct \fig-right : [imginfo] inline-cmd
+  direct \footnote : [inline-text] inline-cmd
   % }}}
 
 end = struct
@@ -83,6 +85,7 @@ end = struct
   let font-size-date  = 18pt
   let font-size-institute  = 20pt
   let font-size-section = 28pt
+  let font-size-footnote = 12pt
 
   % PowerPoint の文書サイズに合わせる
   % let paper-width  = 12.8cm
@@ -94,7 +97,7 @@ end = struct
   let footer-height = 24pt
   let text-horizontal-margin = 30pt
   let text-vertical-margin = font-size-normal *' 1.0
-  let text-height = paper-height -' text-vertical-margin *' 2. -' footer-height -' header-height
+  let text-height = paper-height -' text-vertical-margin *' 2.
   let text-width  = paper-width -' text-horizontal-margin *' 2.
   let text-origin = (text-horizontal-margin, header-height)
 
@@ -192,10 +195,12 @@ end = struct
 
     let bb-main = read-block ctx-doc inner in
 
-    let pagecontf _ = (|
-      text-origin = (text-horizontal-margin, text-vertical-margin);
-      text-height = text-height;
-    |)
+    let pagecontf _ =
+      let () = FootnoteScheme.start-page () in
+      (|
+        text-origin = (text-horizontal-margin, text-vertical-margin);
+        text-height = text-height;
+      |)
     in
 
     let pagepartsf pbinfo =
@@ -439,7 +444,7 @@ end = struct
     in
     let ib-inner = embed-block-top ctx text-width (fun ctx -> read-block ctx inner) in
     let bb-inner = line-break false false ctx ib-inner in
-    let glue-height = (text-height -' get-natural-length bb-inner -' get-natural-length bb-title) *' .5 in
+    let glue-height = (text-height -' footer-height -' header-height -' get-natural-length bb-inner -' get-natural-length bb-title) *' .5 in
     let bb-glue = make-placeholder ctx glue-height in
     (clear-page-or-nil is-first-page) +++
     (bb-bg ctx !draft-mode) +++
@@ -450,7 +455,7 @@ end = struct
   let-block ctx +frame-nt inner =
     let ib-inner = embed-block-top ctx text-width (fun ctx -> read-block ctx inner) in
     let bb-inner = line-break false false ctx ib-inner in
-    let glue-height = (text-height -' get-natural-length bb-inner) *' .5 in
+    let glue-height = (text-height -' footer-height -' header-height -' get-natural-length bb-inner) *' .5 in
     let bb-glue = make-placeholder ctx glue-height in
     % bb-glue +++ bb-inner +++ clear-page
     (clear-page-or-nil is-first-page) +++
@@ -686,6 +691,32 @@ end = struct
 
       % }}}
 
+    % \footnote{} command {{{
+  let-inline ctx \footnote it =
+    let size = get-font-size ctx in
+    let ibf num =
+      let it-num = embed-string (arabic num) in
+      let ctx =
+        ctx |> set-font-size (size *' 0.75)
+            |> set-manual-rising (size *' 0.25)
+      in
+        read-inline ctx {\*#it-num;}
+    in
+    let bbf num =
+      let it-num = embed-string (arabic num) in
+      let ctx =
+        ctx |> set-font-size (font-size-footnote *' 0.9)
+            |> set-leading (font-size-footnote *' 1.2)
+            |> set-paragraph-margin (font-size-footnote *' 0.5) (font-size-footnote *' 0.5)
+          %temporary
+      in
+        line-break false false ctx (read-inline ctx {#it-num; #it;} ++ inline-fil)
+    in
+      FootnoteScheme.main ctx ibf bbf
+
+
+    %}}}
+    
 end
 
 

--- a/slydifi.satyh
+++ b/slydifi.satyh
@@ -72,8 +72,8 @@ module Slydifi : sig
   direct +fig-abs-pos : [(length * length); imginfo] block-cmd
   direct \fig-right : [imginfo] inline-cmd
   direct \footnote : [inline-text] inline-cmd
-  direct \footnote-just : [string; inline-text] inline-cmd
-  direct \ref-footnote : [string] inline-cmd
+  direct \footnotetext : [string; inline-text] inline-cmd
+  direct \footnotemark : [string] inline-cmd
   % }}}
 
 end = struct
@@ -696,7 +696,7 @@ end = struct
     % \footnote{} command {{{
 
 
-  let-inline ctx \footnote-just ref-label it =
+  let-inline ctx \footnotetext ref-label it =
     let bbf num =
       let it-num = embed-string (arabic num) in
       let ctx =
@@ -709,7 +709,7 @@ end = struct
     in
       FootnoteScheme.main ctx (Some(ref-label)) (fun _ -> inline-nil) bbf
 
-  let-inline ctx \ref-footnote ref-label =
+  let-inline ctx \footnotemark ref-label =
     let size = get-font-size ctx in
     let ctx =
       ctx |> set-font-size (size *' 0.75)


### PR DESCRIPTION
stdjbookなどと同様の`\footnote`の追加です。脚註のフォントのサイズは`font-size-footnote`で定義しています。
### `text-height`の変更
`text-height`には余白は入りませんがheaderとfooterは(おそらく)含まれると思います(https://twitter.com/bd_gfngfn/status/1186149675243462657)
分かりやすさのため名前の整合性を優先し、`let text-height`の箇所で変更しましたが`pageconf`で補正を掛けても問題ない気もします。