### PR TITLE
figbox.satyh に関する追記

### DIFF
--- a/Satyristes
+++ b/Satyristes
@@ -8,6 +8,7 @@
     ((package "functions/color.satyh" "./src/functions/color.satyh")
      (package "functions/enumitem.satyh" "./src/functions/enumitem.satyh")
      (package "functions/footnote.satyh" "./src/functions/footnote.satyh")
+     (package "functions/figbox.satyh" "./src/functions/figbox.satyh")
      (package "theme/akasaka.satyh" "./src/theme/akasaka.satyh")
      (package "theme/hakodate.satyh" "./src/theme/hakodate.satyh")
      (package "theme/plain.satyh" "./src/theme/plain.satyh")

--- a/demo/slide.saty
+++ b/demo/slide.saty
@@ -4,6 +4,7 @@
 @require: code
 @require: annot
 @require: list
+@require: class-slydifi/functions/figbox
 @require: class-slydifi/theme/hakodate
 
 open FigBox

--- a/src/theme/hakodate.satyh
+++ b/src/theme/hakodate.satyh
@@ -488,4 +488,3 @@ end = struct
   % }}}
 
 end
-


### PR DESCRIPTION
`figbox` について追記忘れと思しき行を足すPRです．

手元でOPAMとSatyrographosで `satysfi-class-slydifi` の `0.1.0` をインストールした下で  `demo/slide.saty` を処理しようとしましたが，次のように出てエラーとなりました：

```console
! [Type Error] at "slide.saty", line 9, characters 5-11:
    undefined module name 'FigBox'
```

どうやらSatyrographosによるインストール結果では `~/.satysfi/dist/packages/class-slydifi/figbox.satyh` が存在しておらず，またそれを `slide.saty` （やそれが依存するパッケージファイル）の側で読み込んでいる記述もないと見受けたので，その旨を追記したものです．